### PR TITLE
feat: add rename command

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,9 @@ php artisan channels:remove
 
 # Mute a channel to stop receiving notifications
 php artisan channels:mute
+
+# Rename an existing channel you've added!
+php artisan channels:rename
 ```
 
 ### Video Management

--- a/app/Console/Commands/Channels/RenameChannelCommand.php
+++ b/app/Console/Commands/Channels/RenameChannelCommand.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands\Channels;
+
+use App\Models\Channel;
+use Illuminate\Console\Command;
+
+use function Laravel\Prompts\suggest;
+use function Laravel\Prompts\text;
+
+/**
+ * Class RenameChannelCommand
+ *
+ * This command is responsible for renaming a channel you've already added.
+ */
+class RenameChannelCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'channels:rename';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Rename a channel you have already added.';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): void
+    {
+        $channelName = suggest(
+            label: 'Current channel name?',
+            options: fn (string $value) => $value !== ''
+                ? Channel::whereLike('name', "%{$value}%")->pluck('name', 'id')->all()
+                : [],
+            required: true,
+            hint: 'This is the current of the channel you want to rename.',
+        );
+
+        $channel = $this->findChannel($channelName);
+
+        if (! $channel) {
+            $this->components->error('A channel cannot be found with that name. Please run `php artisan channels:list`.');
+
+            return;
+        }
+
+        $newName = text(
+            label: 'New channel name?',
+            required: true,
+            hint: 'Please enter the new channel name.'
+        );
+
+        $this->renameChannel($channel, $newName);
+
+        $this->components->success("The channel '{$channelName}' has been renamed to '{$newName}'.");
+    }
+
+    /**
+     * Find a channel by name.
+     */
+    protected function findChannel(string $channelName): ?Channel
+    {
+        return Channel::where('name', $channelName)->first();
+    }
+
+    /**
+     * Rename a channel's name to something different.
+     */
+    protected function renameChannel(Channel $channel, string $newLabel): bool
+    {
+        $channel->forceFill([
+            'name' => $newLabel,
+        ]);
+
+        return $channel->save();
+    }
+}

--- a/tests/Feature/Commands/Channels/RenameChannelCommandTest.php
+++ b/tests/Feature/Commands/Channels/RenameChannelCommandTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Console\Commands\Channels\RenameChannelCommand;
+use App\Models\Channel;
+
+it('can rename a channel', function (): void {
+    $channel = Channel::factory()->create(['name' => 'First Name']);
+
+    $this->artisan(RenameChannelCommand::class)
+        ->expectsQuestion('Current channel name?', 'First Name')
+        ->expectsQuestion('New channel name?', 'Second Name')
+        ->expectsOutputToContain("The channel '{$channel->name}' has been renamed to 'Second Name'.");
+
+    $channel = $channel->refresh();
+
+    $this->assertEquals($channel->name, 'Second Name');
+});
+
+it('outputs a message if it cannot find a channel', function (): void {
+    $this->artisan(RenameChannelCommand::class)
+        ->expectsQuestion('Current channel name?', 'does-not-exist')
+        ->expectsOutputToContain('A channel cannot be found with that name. Please run `php artisan channels:list`.');
+
+    $this->assertDatabaseMissing('channels', [
+        'name' => 'does-not-exist',
+    ]);
+});

--- a/tests/Feature/Commands/Channels/RenameChannelCommandTest.php
+++ b/tests/Feature/Commands/Channels/RenameChannelCommandTest.php
@@ -27,3 +27,16 @@ it('outputs a message if it cannot find a channel', function (): void {
         'name' => 'does-not-exist',
     ]);
 });
+
+it('prevents renaming to a name that already exists', function (): void {
+    Channel::factory()->create(['name' => 'First Channel']);
+    $channelToRename = Channel::factory()->create(['name' => 'Second Channel']);
+
+    $this->artisan(RenameChannelCommand::class)
+        ->expectsQuestion('Current channel name?', 'Second Channel')
+        ->expectsQuestion('New channel name?', 'First Channel')
+        ->expectsOutputToContain("A channel with the name 'First Channel' already exists. Channel names must be unique.");
+
+    $channelToRename->refresh();
+    $this->assertEquals('Second Channel', $channelToRename->getAttribute('name'));
+});


### PR DESCRIPTION
This PR introduces a `channels:rename` command that lets you rename a pre-existing channel.