### PR TITLE
feat: add notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,9 @@ php artisan channels:mute
 # Rename an existing channel you've added!
 php artisan channels:rename
 
+# Add a note to a channel (viewable with the `list` command)
+php artisan channels:note
+
 # View statistics about your channels
 php artisan other:stats
 

--- a/app/Console/Commands/Channels/ListChannelsCommand.php
+++ b/app/Console/Commands/Channels/ListChannelsCommand.php
@@ -38,7 +38,7 @@ class ListChannelsCommand extends Command
         $channels = Channel::orderBy('created_at', 'desc')->get();
 
         $this->table(
-            ['Name', 'Videos Stored', 'Last Video Grabbed', 'Last Notification', 'Channel URL', 'Muted'],
+            ['Name', 'Videos Stored', 'Last Video Grabbed', 'Last Notification', 'Channel URL', 'Muted', 'Note'],
             $channels->map(function (Channel $channel) {
 
                 $latestNotifiedVideo = $channel->videos()
@@ -53,6 +53,7 @@ class ListChannelsCommand extends Command
                     $latestNotifiedVideo?->notified_at?->setTimezone(config('app.user_timezone'))->diffForHumans() ?? '—',
                     $channel->getChannelUrl(),
                     $channel->isMuted() ? '✔' : '✘',
+                    $channel->note ?: '—',
                 ];
             })->toArray()
         );

--- a/app/Console/Commands/Channels/UpdateNoteCommand.php
+++ b/app/Console/Commands/Channels/UpdateNoteCommand.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands\Channels;
+
+use App\Models\Channel;
+use Illuminate\Console\Command;
+use Illuminate\Database\Eloquent\Builder;
+
+use function Laravel\Prompts\suggest;
+use function Laravel\Prompts\textarea;
+
+/**
+ * Class UpdateNoteCommand
+ *
+ * This command is responsible for updating the note of a channel you've already added.
+ */
+class UpdateNoteCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'channels:note';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Update the note for a channel you have already added.';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): void
+    {
+        $channelName = suggest(
+            label: 'Channel name?',
+            options: fn (string $value) => $value !== ''
+                ? Channel::query()->where(function (Builder $builder) use ($value): void {
+                    $builder->where('name', 'like', "%{$value}%");
+                })->pluck('name', 'id')->all()
+                : [],
+            required: true,
+            hint: 'Select the channel you want to update the note for.',
+        );
+
+        $channel = $this->findChannel($channelName);
+
+        if (! $channel) {
+            $this->components->error('A channel cannot be found with that name. Please run `php artisan channels:list`.');
+
+            return;
+        }
+
+        $currentNote = $channel->getAttribute('note');
+
+        // Display current note if it exists
+        if ($currentNote) {
+            $this->components->info("Current note for '{$channelName}':");
+            $this->line($currentNote);
+        } else {
+            $this->components->info("No note currently exists for '{$channelName}'.");
+        }
+        $this->newLine();
+
+        $newNote = textarea(
+            label: 'Channel note',
+            placeholder: $currentNote ?: 'Enter your note here...',
+            default: $currentNote ?: '',
+            required: false,
+            hint: 'Enter the note for this channel. Leave empty to remove the note.',
+        );
+
+        // Handle empty note (remove note)
+        if (empty(trim($newNote))) {
+            if ($currentNote) {
+                if (! $this->updateChannelNote($channel, null)) {
+                    $this->components->error('Failed to remove the note.');
+
+                    return;
+                }
+                $this->components->success("The note for channel '{$channelName}' has been removed.");
+            } else {
+                $this->components->info("No changes made to channel '{$channelName}'.");
+            }
+
+            return;
+        }
+
+        // Update the note
+        if (! $this->updateChannelNote($channel, $newNote)) {
+            $this->components->error('Failed to update the note.');
+
+            return;
+        }
+
+        if ($currentNote) {
+            $this->components->success("The note for channel '{$channelName}' has been updated.");
+        } else {
+            $this->components->success("A note has been added to channel '{$channelName}'.");
+        }
+    }
+
+    /**
+     * Find a channel by name.
+     */
+    protected function findChannel(string $channelName): ?Channel
+    {
+        return Channel::query()->where('name', $channelName)->first();
+    }
+
+    /**
+     * Update a channel's note.
+     */
+    protected function updateChannelNote(Channel $channel, ?string $note): bool
+    {
+        $channel->forceFill([
+            'note' => $note,
+        ]);
+
+        return $channel->save();
+    }
+}

--- a/database/factories/ChannelFactory.php
+++ b/database/factories/ChannelFactory.php
@@ -28,6 +28,7 @@ class ChannelFactory extends Factory
             'channel_id' => fake()->regexify('[A-Za-z0-9_-]{24}'), // Mimics YouTube channel ID format
             'last_checked_at' => null, // Initial state for new channels
             'muted_at' => null,
+            'note' => fake()->optional(0.3)->sentence(), // Optional note with 30% chance of being set
         ];
     }
 

--- a/database/migrations/2025_06_23_213146_add_note_to_channels_table.php
+++ b/database/migrations/2025_06_23_213146_add_note_to_channels_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('channels', function (Blueprint $table) {
+            $table->text('note')->nullable()->comment('Additional notes or comments about the channel');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('channels', function (Blueprint $table) {
+            $table->dropColumn('note');
+        });
+    }
+};

--- a/tests/Feature/Commands/Channels/UpdateNoteCommandTest.php
+++ b/tests/Feature/Commands/Channels/UpdateNoteCommandTest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Console\Commands\Channels\UpdateNoteCommand;
+use App\Models\Channel;
+
+it('can add a note to a channel that has no existing note', function (): void {
+    $channel = Channel::factory()->create(['name' => 'Test Channel', 'note' => null]);
+
+    $this->artisan(UpdateNoteCommand::class)
+        ->expectsQuestion('Channel name?', 'Test Channel')
+        ->expectsQuestion('Channel note', 'This is my new note')
+        ->expectsOutputToContain("A note has been added to channel 'Test Channel'.");
+
+    $channel = $channel->refresh();
+
+    $this->assertEquals('This is my new note', $channel->note);
+});
+
+it('can update an existing note on a channel', function (): void {
+    $channel = Channel::factory()->create([
+        'name' => 'Test Channel',
+        'note' => 'Original note content',
+    ]);
+
+    $this->artisan(UpdateNoteCommand::class)
+        ->expectsQuestion('Channel name?', 'Test Channel')
+        ->expectsQuestion('Channel note', 'Updated note content')
+        ->expectsOutputToContain("The note for channel 'Test Channel' has been updated.");
+
+    $channel = $channel->refresh();
+
+    $this->assertEquals('Updated note content', $channel->note);
+});
+
+it('can remove a note from a channel by submitting empty text', function (): void {
+    $channel = Channel::factory()->create([
+        'name' => 'Test Channel',
+        'note' => 'Existing note to be removed',
+    ]);
+
+    $this->artisan(UpdateNoteCommand::class)
+        ->expectsQuestion('Channel name?', 'Test Channel')
+        ->expectsQuestion('Channel note', '')
+        ->expectsOutputToContain("The note for channel 'Test Channel' has been removed.");
+
+    $channel = $channel->refresh();
+
+    $this->assertNull($channel->note);
+});
+
+it('shows no changes message when submitting empty text for channel with no existing note', function (): void {
+    $channel = Channel::factory()->create(['name' => 'Test Channel', 'note' => null]);
+
+    $this->artisan(UpdateNoteCommand::class)
+        ->expectsQuestion('Channel name?', 'Test Channel')
+        ->expectsQuestion('Channel note', '')
+        ->expectsOutputToContain("No changes made to channel 'Test Channel'.");
+
+    $channel = $channel->refresh();
+
+    $this->assertNull($channel->note);
+});
+
+it('displays current note when channel has an existing note', function (): void {
+    $channel = Channel::factory()->create([
+        'name' => 'Test Channel',
+        'note' => 'My existing note',
+    ]);
+
+    $this->artisan(UpdateNoteCommand::class)
+        ->expectsQuestion('Channel name?', 'Test Channel')
+        ->expectsOutputToContain("Current note for 'Test Channel':")
+        ->expectsOutputToContain('My existing note')
+        ->expectsQuestion('Channel note', 'Updated note')
+        ->expectsOutputToContain("The note for channel 'Test Channel' has been updated.");
+});
+
+it('displays message when channel has no existing note', function (): void {
+    $channel = Channel::factory()->create(['name' => 'Test Channel', 'note' => null]);
+
+    $this->artisan(UpdateNoteCommand::class)
+        ->expectsQuestion('Channel name?', 'Test Channel')
+        ->expectsOutputToContain("No note currently exists for 'Test Channel'.")
+        ->expectsQuestion('Channel note', 'New note')
+        ->expectsOutputToContain("A note has been added to channel 'Test Channel'.");
+});
+
+it('outputs a message if it cannot find a channel', function (): void {
+    $this->artisan(UpdateNoteCommand::class)
+        ->expectsQuestion('Channel name?', 'does-not-exist')
+        ->expectsOutputToContain('A channel cannot be found with that name. Please run `php artisan channels:list`.');
+
+    $this->assertDatabaseMissing('channels', [
+        'name' => 'does-not-exist',
+    ]);
+});
+
+it('handles multi-line notes correctly', function (): void {
+    $channel = Channel::factory()->create(['name' => 'Test Channel', 'note' => null]);
+
+    $multiLineNote = "This is line one\nThis is line two\nThis is line three";
+
+    $this->artisan(UpdateNoteCommand::class)
+        ->expectsQuestion('Channel name?', 'Test Channel')
+        ->expectsQuestion('Channel note', $multiLineNote)
+        ->expectsOutputToContain("A note has been added to channel 'Test Channel'.");
+
+    $channel = $channel->refresh();
+
+    $this->assertEquals($multiLineNote, $channel->note);
+});
+
+it('handles whitespace-only input as empty note', function (): void {
+    $channel = Channel::factory()->create([
+        'name' => 'Test Channel',
+        'note' => 'Existing note',
+    ]);
+
+    $this->artisan(UpdateNoteCommand::class)
+        ->expectsQuestion('Channel name?', 'Test Channel')
+        ->expectsQuestion('Channel note', '   ')
+        ->expectsOutputToContain("The note for channel 'Test Channel' has been removed.");
+
+    $channel = $channel->refresh();
+
+    $this->assertNull($channel->note);
+});


### PR DESCRIPTION
This PR introduces a notes command which shows text on the `php artisan channels:list` table.