### PR TITLE
feat: summary emails include the day as a heading

### DIFF
--- a/app/Actions/Summaries/FetchRecentVideosForSummary.php
+++ b/app/Actions/Summaries/FetchRecentVideosForSummary.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Summaries;
+
+use App\Models\Video;
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+use Illuminate\Support\Collection;
+
+class FetchRecentVideosForSummary
+{
+    /**
+     * Fetch and group videos from the past week by days.
+     *
+     * @return array<string, array{date: Carbon, videos: EloquentCollection<int, Video>}>
+     */
+    public function execute(): array
+    {
+        $lastWeeksVideos = Video::where('created_at', '>=', now()->subWeek())
+            ->whereNotNull('notified_at') // Only include videos that we've notified the user about
+            ->orderBy('created_at', 'desc')
+            ->with('channel')
+            ->get();
+
+        if ($lastWeeksVideos->isEmpty()) {
+            return [];
+        }
+
+        return $this->groupVideosByDays($lastWeeksVideos);
+    }
+
+    /**
+     * Fetch and group a specific collection of videos by days.
+     * Useful for testing with custom video collections.
+     *
+     * @param  Collection<int, Video>|EloquentCollection<int, Video>  $videos
+     * @return array<string, array{date: Carbon, videos: EloquentCollection<int, Video>}>
+     */
+    public function executeWithVideos(EloquentCollection|Collection $videos): array
+    {
+        if ($videos->isEmpty()) {
+            return [];
+        }
+
+        $videoCollection = $videos instanceof EloquentCollection
+            ? $videos
+            : new EloquentCollection($videos->all());
+
+        return $this->groupVideosByDays($videoCollection);
+    }
+
+    /**
+     * Group videos by days (all days of the week).
+     *
+     * @param  EloquentCollection<int, Video>  $eloquentCollection
+     * @return array<string, array{date: Carbon, videos: EloquentCollection<int, Video>}>
+     */
+    private function groupVideosByDays(EloquentCollection $eloquentCollection): array
+    {
+        $groupedVideos = $eloquentCollection->groupBy(function (Video $video): string {
+            return Carbon::parse($video->created_at)->format('Y-m-d');
+        });
+
+        $days = [];
+        $startOfWeek = now()->subWeek()->startOfWeek(); // Monday of last week
+
+        for ($i = 0; $i < 7; $i++) { // This is Monday to Sunday
+            $date = $startOfWeek->copy()->addDays($i);
+            $dateString = $date->format('Y-m-d');
+
+            if ($groupedVideos->has($dateString)) {
+                $videoCollection = $groupedVideos->get($dateString);
+                if ($videoCollection !== null && $videoCollection->isNotEmpty()) {
+                    $days[$dateString] = [
+                        'date' => $date,
+                        'videos' => $videoCollection,
+                    ];
+                }
+            }
+        }
+
+        return $days;
+    }
+}

--- a/app/Mail/WeeklySummaryMail.php
+++ b/app/Mail/WeeklySummaryMail.php
@@ -4,26 +4,24 @@ declare(strict_types=1);
 
 namespace App\Mail;
 
-use App\Models\Video;
 use Illuminate\Mail\Mailable;
 use Illuminate\Mail\Mailables\Content;
 use Illuminate\Mail\Mailables\Envelope;
-use Illuminate\Support\Collection;
 
 /**
  * Class WeeklySummaryMail
  *
  * This mailable class is responsible for sending a weekly summary email
- * containing a collection of videos.
+ * containing videos grouped by weekdays.
  */
 class WeeklySummaryMail extends Mailable
 {
     /**
      * Create a new message instance.
      *
-     * @param  Collection<int, Video>  $videos  A collection of video instances to include in the summary email.
+     * @param  array<string, array{date: \Carbon\Carbon, videos: \Illuminate\Database\Eloquent\Collection<int, \App\Models\Video>}>  $weekdays  An array of weekdays with their videos, grouped by date.
      */
-    public function __construct(private readonly Collection $videos)
+    public function __construct(private readonly array $weekdays)
     {
         $this->locale = config('app.user_language', 'en');
     }
@@ -54,7 +52,7 @@ class WeeklySummaryMail extends Mailable
         return new Content(
             markdown: 'mail.weekly-summary-mail',
             with: [
-                'videos' => $this->videos,
+                'weekdays' => $this->weekdays,
                 'locale' => $this->locale,
             ]
         );

--- a/lang/en/email.php
+++ b/lang/en/email.php
@@ -14,4 +14,11 @@ return [
     'weekly_summary_intro' => 'Here\'s your weekly summary of new uploads from the past week.',
     'weekly_summary_notification_reason' => 'You\'re receiving this email because you enabled Weekly Summaries.',
     'by_creator' => 'by :creator',
+    'weekday_monday' => 'Monday',
+    'weekday_tuesday' => 'Tuesday',
+    'weekday_wednesday' => 'Wednesday',
+    'weekday_thursday' => 'Thursday',
+    'weekday_friday' => 'Friday',
+    'weekday_saturday' => 'Saturday',
+    'weekday_sunday' => 'Sunday',
 ];

--- a/resources/views/mail/weekly-summary-mail.blade.php
+++ b/resources/views/mail/weekly-summary-mail.blade.php
@@ -8,12 +8,18 @@ declare(strict_types=1);
 
 {{ __('email.weekly_summary_intro') }}
 
-@foreach($videos as $video)
+@foreach($weekdays as $dateString => $dayData)
+<div style="margin: 40px 0 30px 0;">
+<h2 style="font-size: 22px; color: #1f2937; margin: 0 0 20px 0; padding-bottom: 10px; border-bottom: 2px solid #e5e7eb;">
+{{ __('email.weekday_' . strtolower($dayData['date']->format('l'))) }} - {{ $dayData['date']->format('M j, Y') }}
+</h2>
+
+@foreach($dayData['videos'] as $video)
 <div style="margin-bottom: 30px; padding: 20px; border: 1px solid #e5e7eb; border-radius: 8px; background-color: #f9fafb;">
 <div style="display: flex; align-items: center; margin-bottom: 15px;">
 <div style="flex: 1;">
 <h3 style="margin: 0 0 5px 0; font-size: 18px; color: #1f2937;">
- <a href="{{ $video->getYoutubeUrl() }}" style="text-decoration: none; color: #1f2937;">
+<a href="{{ $video->getYoutubeUrl() }}" style="text-decoration: none; color: #1f2937;">
 {{ $video->title }}
 </a>
 </h3>
@@ -21,7 +27,7 @@ declare(strict_types=1);
 @if(isset($video->channel))
 {!! __('email.by_creator', ['creator' => '<a href="' . $video->channel->getChannelUrl() . '" style="color: #dc2626; text-decoration: none;">' . $video->channel->name . '</a>']) !!}
 • {{ $video->getFormattedPublishedDate() }}
- @endif
+@endif
 </p>
 </div>
 </div>
@@ -40,6 +46,8 @@ declare(strict_types=1);
 {{ __('email.watch_on_youtube') }}
 </x-mail::button>
 </div>
+</div>
+@endforeach
 </div>
 @endforeach
 <x-mail::subcopy>

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Actions\Summaries\FetchRecentVideosForSummary;
 use App\Mail\NewVideoMail;
 use App\Mail\WeeklySummaryMail;
 use App\Models\Channel;
@@ -23,14 +24,56 @@ Route::get('/mail', function () {
     return (new NewVideoMail($video, $channel))->render();
 });
 
-Route::get('/mail/weekly-summary', function () {
+Route::get('/mail/weekly-summary', function (FetchRecentVideosForSummary $fetchRecentVideosForSummary) {
     if (! Config::get('app.debug')) {
         abort(404);
     }
 
-    $videos = Video::factory()->count(24)->create([
-        'created_at' => now()->subDays(3),
-    ]);
+    $videos = collect();
 
-    return (new WeeklySummaryMail($videos))->render();
+    $mondayVideos = Video::factory()->count(3)->create([
+        'created_at' => now()->subWeek()->startOfWeek(), // Monday
+        'notified_at' => now()->subWeek()->startOfWeek()->addHour(),
+    ]);
+    $videos = $videos->merge($mondayVideos);
+
+    $tuesdayVideos = Video::factory()->count(4)->create([
+        'created_at' => now()->subWeek()->startOfWeek()->addDay(), // Tuesday
+        'notified_at' => now()->subWeek()->startOfWeek()->addDay()->addHour(),
+    ]);
+    $videos = $videos->merge($tuesdayVideos);
+
+    $wednesdayVideos = Video::factory()->count(5)->create([
+        'created_at' => now()->subWeek()->startOfWeek()->addDays(2), // Wednesday
+        'notified_at' => now()->subWeek()->startOfWeek()->addDays(2)->addHour(),
+    ]);
+    $videos = $videos->merge($wednesdayVideos);
+
+    $thursdayVideos = Video::factory()->count(3)->create([
+        'created_at' => now()->subWeek()->startOfWeek()->addDays(3), // Thursday
+        'notified_at' => now()->subWeek()->startOfWeek()->addDays(3)->addHour(),
+    ]);
+    $videos = $videos->merge($thursdayVideos);
+
+    $fridayVideos = Video::factory()->count(2)->create([
+        'created_at' => now()->subWeek()->startOfWeek()->addDays(4), // Friday
+        'notified_at' => now()->subWeek()->startOfWeek()->addDays(4)->addHour(),
+    ]);
+    $videos = $videos->merge($fridayVideos);
+
+    $saturdayVideos = Video::factory()->count(1)->create([
+        'created_at' => now()->subWeek()->startOfWeek()->addDays(5), // Saturday
+        'notified_at' => now()->subWeek()->startOfWeek()->addDays(5)->addHour(),
+    ]);
+    $videos = $videos->merge($saturdayVideos);
+
+    $sundayVideos = Video::factory()->count(3)->create([
+        'created_at' => now()->subWeek()->startOfWeek()->addDays(6), // Sunday
+        'notified_at' => now()->subWeek()->startOfWeek()->addDays(6)->addHour(),
+    ]);
+    $videos = $videos->merge($sundayVideos);
+
+    $weekdays = $fetchRecentVideosForSummary->executeWithVideos($videos);
+
+    return (new WeeklySummaryMail($weekdays))->render();
 });

--- a/tests/Feature/Commands/Summaries/DispatchWeeklySummaryCommandTest.php
+++ b/tests/Feature/Commands/Summaries/DispatchWeeklySummaryCommandTest.php
@@ -32,7 +32,7 @@ it('outputs a message when no new uploads are found for the past week', function
     ]);
 
     $this->artisan(DispatchWeeklySummaryCommand::class)
-        ->expectsOutputToContain('No new uploads found for the past week.')
+        ->expectsOutputToContain('No new uploads found for weekdays in the past week.')
         ->assertExitCode(0);
 
     expect(Video::where('created_at', '>=', now()->subWeek())->count())->toBe(0);

--- a/tests/Feature/Mail/WeeklySummaryMailTest.php
+++ b/tests/Feature/Mail/WeeklySummaryMailTest.php
@@ -2,9 +2,11 @@
 
 declare(strict_types=1);
 
+use App\Actions\Summaries\FetchRecentVideosForSummary;
 use App\Mail\WeeklySummaryMail;
 use App\Models\Channel;
 use App\Models\Video;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 
 it('builds the mail correctly', function (): void {
     $creator1 = Channel::factory()->create(['name' => 'Creator One']);
@@ -12,31 +14,40 @@ it('builds the mail correctly', function (): void {
 
     $video1 = Video::factory()->create([
         'channel_id' => $creator1->id,
-        'created_at' => now()->startOfWeek()->addHours(10), // Monday
+        'created_at' => now()->subWeek()->startOfWeek()->addHours(10), // Monday of last week
+        'notified_at' => now()->subWeek()->startOfWeek()->addHours(11),
     ]);
 
     $video2 = Video::factory()->create([
         'channel_id' => $creator2->id,
-        'created_at' => now()->startOfWeek()->addDays(1)->addHours(14), // Tuesday
+        'created_at' => now()->subWeek()->startOfWeek()->addDays(1)->addHours(14), // Tuesday of last week
+        'notified_at' => now()->subWeek()->startOfWeek()->addDays(1)->addHours(15),
     ]);
 
     $video3 = Video::factory()->create([
         'channel_id' => $creator1->id,
-        'created_at' => now()->startOfWeek()->addDays(2)->addHours(9), // Wednesday
+        'created_at' => now()->subWeek()->startOfWeek()->addDays(2)->addHours(9), // Wednesday of last week
+        'notified_at' => now()->subWeek()->startOfWeek()->addDays(2)->addHours(10),
     ]);
 
-    $videos = collect([$video1->load('channel'), $video2->load('channel'), $video3->load('channel')]);
+    $videos = new EloquentCollection([$video1->load('channel'), $video2->load('channel'), $video3->load('channel')]);
 
-    $mailable = new WeeklySummaryMail($videos);
+    $fetchAction = new FetchRecentVideosForSummary;
+    $weekdays = $fetchAction->executeWithVideos($videos);
+
+    $mailable = new WeeklySummaryMail($weekdays);
 
     $mailable->assertHasSubject(__('email.weekly_summary_subject'));
     $mailable->assertSeeInText(__('email.weekly_summary_intro'));
-
     $mailable->assertSeeInText('Creator One');
     $mailable->assertSeeInText('Creator Two');
-
-    // Check that all video titles appear in the email
     $mailable->assertSeeInText($video1->title);
     $mailable->assertSeeInText($video2->title);
     $mailable->assertSeeInText($video3->title);
+    $mailable->assertSeeInText(__('email.weekday_monday'));
+    $mailable->assertSeeInText(__('email.weekday_tuesday'));
+    $mailable->assertSeeInText(__('email.weekday_wednesday'));
+    $mailable->assertSeeInText(now()->subWeek()->startOfWeek()->format('M j, Y')); // Monday date
+    $mailable->assertSeeInText(now()->subWeek()->startOfWeek()->addDay()->format('M j, Y')); // Tuesday date
+    $mailable->assertSeeInText(now()->subWeek()->startOfWeek()->addDays(2)->format('M j, Y')); // Wednesday date
 });


### PR DESCRIPTION
This PR adds the day of the week to the summary email, and also extracts the summarizing logic into an action for improved readability. 