### PR TITLE
[codex] Update GitHub Actions Node version

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -27,9 +27,9 @@ jobs:
           coverage: xdebug
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20.19'
           cache: 'npm'
 
       - name: Install Composer Dependencies

--- a/.github/workflows/rector.yml
+++ b/.github/workflows/rector.yml
@@ -27,9 +27,9 @@ jobs:
           coverage: xdebug
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20.19'
           cache: 'npm'
 
       - name: Install Composer Dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,9 +27,9 @@ jobs:
           coverage: xdebug
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20.19'
           cache: 'npm'
 
       - name: Install Composer Dependencies


### PR DESCRIPTION
## Summary
- Update GitHub Actions workflows that build Vite assets from Node 18 to Node 20.19
- Refresh setup-node from v3 to v4 in those workflows

## Why
Vite now requires Node.js 20.19+ or 22.12+, so CI jobs using Node 18 fail before assets can build.

## Validation
- npm run build